### PR TITLE
Fixed npm typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Yoy should have [https://github.com/hugozap/react-rotary-knob](https://github.co
 
 or
 
-`npm install react-rotary-knob-skins-pack --save`
+`npm install react-rotary-knob-skin-pack --save`
 
 # Usage
 


### PR DESCRIPTION
updated package name from "react-rotary-knob-skins-pack" to "react-rotary-knob-skin-pack"